### PR TITLE
fem.py voltage_meter is hard coded to only use 16 electrodes, updated function. 

### DIFF
--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -97,7 +97,7 @@ class Forward(object):
             f_el = f[self.el_pos]
 
             # boundary measurements, subtract_row-voltages on electrodes
-            diff_op = voltage_meter(ex_line, step=step, parser=parser)
+            diff_op = voltage_meter(ex_line, n_el=self.ne,step=step, parser=parser)
             v_diff = subtract_row(f_el, diff_op)
             jac_diff = subtract_row(jac_i, diff_op)
 


### PR DESCRIPTION
Updated call to solve_eit function where voltage_meter is called. Call to Voltage_meter must have a flexible number of electrodes otherwise all pyEIT is limited to 16 electrodes calculations. 