### PR TITLE
Removed argument from build function

### DIFF
--- a/pyeit/mesh/shell.py
+++ b/pyeit/mesh/shell.py
@@ -122,7 +122,7 @@ def multi_circle(r=1., background=1., n_el=16, h0=0.006,
             p_fix = np.vstack([p_fix, p_fix_layer])
 
     # 3. build triangle (more frequently control the nodes)
-    p, t = build(_fd, _fh, pfix=p_fix, h0=h0, densityctrlfreq=10, deltat=0.2)
+    p, t = build(_fd, _fh, pfix=p_fix, h0=h0, densityctrlfreq=10)
 
     # check whether t is counter-clock-wise, otherwise reshape it
     t = check_order(p, t)


### PR DESCRIPTION
The multi-shell example (`examples/mesh_multi_shell.py`) was throwing the error

```
Traceback (most recent call last):

  File "/Users/spors/Documents/src/pyEIT/examples/mesh_multi_shell.py", line 29, in <module>
    ppl=64)

  File "/Users/spors/Documents/src/pyEIT/pyeit/mesh/shell.py", line 125, in multi_circle
    p, t = build(_fd, _fh, pfix=p_fix, h0=h0, densityctrlfreq=10, deltat=0.2)

TypeError: build() got an unexpected keyword argument 'deltat'
```

Removing the argument and checking the results seem to provide the desired mesh. However, only the `multi_circle` results are plotted in the original code.