### PR TITLE
transposing the second member on the dot operation

### DIFF
--- a/pyeit/eit/base.py
+++ b/pyeit/eit/base.py
@@ -130,8 +130,8 @@ class EitBase:
             dv = self.normalize(v1, v0)
         else:
             dv = v1 - v0
-
-        ds = -np.dot(self.H, dv)  # s = -Hv
+        
+        ds = -np.dot(self.H, dv.transpose())  # s = -Hv
         if log_scale:
             ds = np.exp(ds) - 1.0
 


### PR DESCRIPTION
Only adding the transpose in the dot operation to make it work when using multiple measurement vector (MMV)