### PR TITLE
Forward vectorization

### DIFF
--- a/examples/eit_static_jac.py
+++ b/examples/eit_static_jac.py
@@ -15,7 +15,7 @@ from pyeit.mesh.shape import thorax
 import pyeit.eit.jac as jac
 
 """ 1. setup """
-n_el = 16
+n_el = 64
 # Mesh shape is specified with fd parameter in the instantiation, e.g : fd=thorax , Default :fd=circle
 mesh_obj, el_pos = create(n_el, h0=0.05, fd=thorax)
 # test function for altering the permittivity in mesh
@@ -46,14 +46,14 @@ ax.set_title(r"$\Delta$ Conductivities")
 el_dist, step = 1, 1
 ex_mat = eit_scan_lines(n_el, el_dist)
 fwd = Forward(mesh_obj, el_pos)
-f1 = fwd.solve_eit(ex_mat, step, perm=mesh_new["perm"], parser="std")
+f1 = fwd.solve_eit(ex_mat, step, perm=mesh_new["perm"], parser="std", vector=True)
 
 """ 3. solve_eit using gaussian-newton (with regularization) """
 # number of stimulation lines/patterns
 eit = jac.JAC(mesh_obj, el_pos, ex_mat, step, perm=1.0, parser="std")
 eit.setup(p=0.25, lamb=1.0, method="lm")
 # lamb = lamb * lamb_decay
-ds = eit.gn(f1.v, lamb_decay=0.1, lamb_min=1e-5, maxiter=20, verbose=True)
+ds = eit.gn(f1.v, lamb_decay=0.1, lamb_min=1e-5, maxiter=20, verbose=True, vector=True)
 
 # plot
 ax = axes[1]

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -101,7 +101,9 @@ class Forward:
             f_el = f[:, self.el_pos]
 
             # boundary measurements, subtract_row-voltages on electrodes
-            diff_op = voltage_meter_nd(ex_mat, n_el=self.ne, step=step, parser=parser).astype(int)
+            diff_op = voltage_meter_nd(
+                ex_mat, n_el=self.ne, step=step, parser=parser
+            ).astype(int)
             v = subtract_row_nd(f_el, diff_op)
             jac = subtract_row_nd(jac_i, diff_op)
 
@@ -313,10 +315,10 @@ def smear(f, fb, pairs):
     """
 
     # Replacing the code below by a faster implementation in Numpy
-    f_min, f_max = np.minimum(fb[pairs[:, 0]], fb[pairs[:, 1]]).reshape((-1, 1)), np.maximum(fb[pairs[:, 0]],
-                                                                                             fb[pairs[:, 1]]).reshape(
-        (-1, 1))
-    b_matrix = ((f_min < f) & (f <= f_max))
+    f_min, f_max = np.minimum(fb[pairs[:, 0]], fb[pairs[:, 1]]).reshape(
+        (-1, 1)
+    ), np.maximum(fb[pairs[:, 0]], fb[pairs[:, 1]]).reshape((-1, 1))
+    b_matrix = (f_min < f) & (f <= f_max)
 
     # b_matrix = []
     # for i, j in pairs:
@@ -457,10 +459,13 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
     m = a % n_el
     n = (m + step) % n_el
     # if any of the electrodes is the stimulation electrodes
-    diff_pairs_mask = ((m == drv_a) | (m == drv_b) | (n == drv_a) | (
-                n == drv_b)) | meas_current  # Create an array of bool to act as a mask
+    diff_pairs_mask = (
+        (m == drv_a) | (m == drv_b) | (n == drv_a) | (n == drv_b)
+    ) | meas_current  # Create an array of bool to act as a mask
     arr = np.array([n, m]).T  # Create an array with n an m as columns
-    diff_pairs = arr[~np.array(diff_pairs_mask)]  # Remove elements not complying with the mask (eg: False)
+    diff_pairs = arr[
+        ~np.array(diff_pairs_mask)
+    ]  # Remove elements not complying with the mask (eg: False)
 
     # # build differential pairs
     # v = []
@@ -471,7 +476,6 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
     #     if not (m == drv_a or m == drv_b or n == drv_a or n == drv_b) or meas_current:
     #         # the order of m, n matters
     #         v.append([n, m])
-    # 
     # diff_pairs = np.array(v)
     return diff_pairs
 
@@ -533,10 +537,23 @@ def voltage_meter_nd(ex_mat, n_el=16, step=1, parser=None):
     n = (m + step) % n_el
     # if any of the electrodes is the stimulation electrodes
     diff_pairs_mask = np.array(
-        [(((m[i] == drv_a[i]) | (m[i] == drv_b[i]) | (n[i] == drv_a[i]) | (n[i] == drv_b[i])) | meas_current) for i in
-         range(m.shape[0])])
+        [
+            (
+                (
+                    (m[i] == drv_a[i])
+                    | (m[i] == drv_b[i])
+                    | (n[i] == drv_a[i])
+                    | (n[i] == drv_b[i])
+                )
+                | meas_current
+            )
+            for i in range(m.shape[0])
+        ]
+    )
     arr = np.array([np.array([n[i], m[i]]).T for i in range(n.shape[0])])
-    diff_pairs = np.array([arr[i, ~np.array((diff_pairs_mask[i]))] for i in range(arr.shape[0])])
+    diff_pairs = np.array(
+        [arr[i, ~np.array((diff_pairs_mask[i]))] for i in range(arr.shape[0])]
+    )
 
     return diff_pairs
 

--- a/pyeit/eit/jac.py
+++ b/pyeit/eit/jac.py
@@ -78,6 +78,7 @@ class JAC(EitBase):
         lamb_min=0,
         method="kotre",
         verbose=False,
+        vector=False
     ):
         """
         Gaussian Newton Static Solver
@@ -101,6 +102,8 @@ class JAC(EitBase):
             'kotre' or 'lm'
         verbose: bool, optional
             print debug information
+        vector: bool, optional
+            Use vectorized methods or regular methods, for compatibility.
 
         Returns
         -------
@@ -131,7 +134,7 @@ class JAC(EitBase):
 
             # forward solver
             fs = self.fwd.solve_eit(
-                self.ex_mat, step=self.step, perm=x0, parser=self.parser
+                self.ex_mat, step=self.step, perm=x0, parser=self.parser, vector=vector
             )
             # Residual
             r0 = v - fs.v


### PR DESCRIPTION
Hello,

I modified the fem_forward logic to make it capable of working with vectorization. On my computer, it changed the computation time for a 64 electrodes reconstruction from ~40s down to ~15s. It is quite an improvement, and it does allow the user to choose between the regular methods or the new ones, through a single argument in "solve_eit". I ran my tests on your given example (eit_static_jac), and the results are the same between the two possibilities. I spent a lot of time working on the improvement of the algorithms, and you will find each time the previous version (yours) commented out, with the new version (mine) just above.

Docstring is up-to-date and each method, when an entirely new one is required, has the same name as the original, followed by "_nd" (for ndarray). I tried as much as possible to use only the numpy's ufuncs, though sometimes it was hardly possible. I also ran some tests to find out what was the best optimization when it comes to computational cost, and the one I have come up with is for now the best you could have (I would need a lot more time).

Feel free to contact me if you need me.