### PR TITLE
fix diff_pairs_mask to fit original conditions

### DIFF
--- a/examples/eit_static_jac.py
+++ b/examples/eit_static_jac.py
@@ -34,7 +34,7 @@ perm = mesh_new["perm"]
 el_dist, step = 1, 1
 ex_mat = eit_scan_lines(n_el, el_dist)
 fwd = Forward(mesh_obj, el_pos)
-f1 = fwd.solve_eit(ex_mat, step, perm=mesh_new["perm"], parser="std", vector=True)
+f1 = fwd.solve_eit(ex_mat, step, perm=mesh_new["perm"], parser="std")
 
 # plot
 fig, ax = plt.subplots(figsize=(9, 6))
@@ -49,7 +49,7 @@ ax.set_title(r"$\Delta$ Conductivities")
 eit = jac.JAC(mesh_obj, el_pos, ex_mat, step, perm=1.0, parser="std")
 eit.setup(p=0.25, lamb=1.0, method="lm")
 # lamb = lamb * lamb_decay
-ds = eit.gn(f1.v, lamb_decay=0.1, lamb_min=1e-5, maxiter=20, verbose=True, vector=True)
+ds = eit.gn(f1.v, lamb_decay=0.1, lamb_min=1e-5, maxiter=20, verbose=True)
 
 # plot
 fig, ax = plt.subplots(figsize=(9, 6))

--- a/pyeit/eit/base.py
+++ b/pyeit/eit/base.py
@@ -29,7 +29,7 @@ class EitBase:
         perm=None,
         jac_normalized=False,
         parser="std",
-        vector=False,
+        **kwargs,
     ):
         """
         Parameters
@@ -48,8 +48,6 @@ class EitBase:
             normalize the jacobian using f0 computed from input perm
         parser: str, optional, default is 'std'
             parsing the format of each frame in measurement/file
-        vector: bool, optional
-            Use vectorized methods or regular methods, for compatibility.
 
         Notes
         -----
@@ -85,12 +83,9 @@ class EitBase:
         # solving configurations
         self.ex_mat = ex_mat
         self.step = step
-        self.vector = vector
 
         # solving Jacobian using uniform sigma distribution
-        res = fwd.solve_eit(
-            ex_mat, step=step, perm=self.perm, parser=self.parser, vector=self.vector
-        )
+        res = fwd.solve_eit(ex_mat, step=step, perm=self.perm, parser=self.parser)
         self.J, self.v0, self.B = res.jac, res.v, res.b_matrix
 
         # Jacobian normalization: divide each row of J (J[i]) by abs(v0[i])

--- a/pyeit/eit/base.py
+++ b/pyeit/eit/base.py
@@ -29,6 +29,7 @@ class EitBase:
         perm=None,
         jac_normalized=False,
         parser="std",
+        vector=False,
     ):
         """
         Parameters
@@ -47,6 +48,8 @@ class EitBase:
             normalize the jacobian using f0 computed from input perm
         parser: str, optional, default is 'std'
             parsing the format of each frame in measurement/file
+        vector: bool, optional
+            Use vectorized methods or regular methods, for compatibility.
 
         Notes
         -----
@@ -82,9 +85,12 @@ class EitBase:
         # solving configurations
         self.ex_mat = ex_mat
         self.step = step
+        self.vector = vector
 
         # solving Jacobian using uniform sigma distribution
-        res = fwd.solve_eit(ex_mat, step=step, perm=self.perm, parser=self.parser)
+        res = fwd.solve_eit(
+            ex_mat, step=step, perm=self.perm, parser=self.parser, vector=self.vector
+        )
         self.J, self.v0, self.B = res.jac, res.v, res.b_matrix
 
         # Jacobian normalization: divide each row of J (J[i]) by abs(v0[i])

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -535,10 +535,10 @@ def voltage_meter_nd(ex_mat, n_el=16, step=1, parser=None):
         [
             (
                 (
-                    (m[i] == drv_a[i])
-                    | (m[i] == drv_b[i])
-                    | (n[i] == drv_a[i])
-                    | (n[i] == drv_b[i])
+                    (m[i] != drv_a[i])
+                    & (m[i] != drv_b[i])
+                    & (n[i] != drv_a[i])
+                    & (n[i] != drv_b[i])
                 )
                 | meas_current
             )
@@ -546,11 +546,7 @@ def voltage_meter_nd(ex_mat, n_el=16, step=1, parser=None):
         ]
     )
     arr = np.array([np.array([n[i], m[i]]).T for i in range(n.shape[0])])
-    diff_pairs = np.array(
-        [arr[i, ~np.array((diff_pairs_mask[i]))] for i in range(arr.shape[0])]
-    )
-
-    return diff_pairs
+    return np.array([arr[i, np.array((diff_pairs_mask[i]))] for i in range(arr.shape[0])])
 
 
 def assemble(ke, tri, perm, n_pts, ref=0):

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -369,12 +369,6 @@ def subtract_row(v, pairs):
     v_diff: NDArray
         difference measurements
     """
-    # i = pairs[:, 0]
-    # j = pairs[:, 1]
-    # # row-wise/element-wise operation on matrix/vector v
-    # v_diff = v[i] - v[j]
-
-    # Removed unnecessary memory allocation
     return v[pairs[:, 0]] - v[pairs[:, 1]]
 
 
@@ -427,12 +421,12 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
     parser: str or list[str]
         if parser contains 'fmmu', or 'rotate_meas' then data are trimmed,
         boundary voltage measurements are re-indexed and rotated,
-        start from the positive stimulus electrodestart index 'A'.
+        start from the positive stimulus electrode start index 'A'.
         if parser contains 'std', or 'no_rotate_meas' then data are trimmed,
         the start index (i) of boundary voltage measurements is always 0.
-        if parser contains 'meas_current', mesurements on all will be carried,
-        otherwise (if not contained, of if 'no_meas_current' is contained)
-        mesurements on current carrying electrodes are discarded.
+        if parser contains 'meas_current', the measurements on current carrying
+        electrodes are allowed. Otherwise the measurements on current carrying
+        electrodes are discarded (like 'no_meas_current' option in EIDORS3D).
 
     Returns
     -------
@@ -446,7 +440,9 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
     if not isinstance(parser, list):  # transform parser in list
         parser = [parser]
 
-    meas_current = "meas_current" in parser
+    meas_current = (
+        "meas_current" in parser
+    )  # flag for measurements on current carrying electrodes
     fmmu_rotate = any(p in ("fmmu", "rotate_meas") for p in parser)
     i0 = drv_a if fmmu_rotate else 0
 
@@ -460,7 +456,7 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
         ((m != drv_a) & (m != drv_b) & (n != drv_a) & (n != drv_b)) | meas_current
     )  # Create an array of bool to act as a mask
     arr = np.array([n, m]).T  # Create an array with n an m as columns
-    # Remove elements not complying with the mask (eg: False)
+    # Remove elements complying with the mask (eg: True)
     # diff_pairs = arr[diff_pairs_mask] Removed inutile memory alloc
     # # build differential pairs
     # v = []
@@ -491,9 +487,6 @@ def voltage_meter_nd(ex_mat, n_el=16, step=1, parser=None):
     B: current sink,
     M, N: boundary electrodes, where v_diff = v_n - v_m.
 
-    'no_meas_current': (EIDORS3D)
-    mesurements on current carrying electrodes are discarded.
-
     Parameters
     ----------
     ex_line: NDArray
@@ -502,12 +495,15 @@ def voltage_meter_nd(ex_mat, n_el=16, step=1, parser=None):
         number of total electrodes.
     step: int
         measurement method (two adjacent electrodes are used for measuring).
-    parser: str
-        if parser is 'fmmu', or 'rotate_meas' then data are trimmed,
+    parser: str or list[str]
+        if parser contains 'fmmu', or 'rotate_meas' then data are trimmed,
         boundary voltage measurements are re-indexed and rotated,
-        start from the positive stimulus electrodestart index 'A'.
-        if parser is 'std', or 'no_rotate_meas' then data are trimmed,
+        start from the positive stimulus electrode start index 'A'.
+        if parser contains 'std', or 'no_rotate_meas' then data are trimmed,
         the start index (i) of boundary voltage measurements is always 0.
+        if parser contains 'meas_current', the measurements on current carrying
+        electrodes are allowed. Otherwise the measurements on current carrying
+        electrodes are discarded (like 'no_meas_current' option in EIDORS3D).
 
     Returns
     -------
@@ -546,7 +542,9 @@ def voltage_meter_nd(ex_mat, n_el=16, step=1, parser=None):
         ]
     )
     arr = np.array([np.array([n[i], m[i]]).T for i in range(n.shape[0])])
-    return np.array([arr[i, np.array((diff_pairs_mask[i]))] for i in range(arr.shape[0])])
+    return np.array(
+        [arr[i, np.array((diff_pairs_mask[i]))] for i in range(arr.shape[0])]
+    )
 
 
 def assemble(ke, tri, perm, n_pts, ref=0):

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -456,14 +456,12 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
     m = a % n_el
     n = (m + step) % n_el
     # if any of the electrodes is the stimulation electrodes
-    diff_pairs_mask = (
-        (m == drv_a) | (m == drv_b) | (n == drv_a) | (n == drv_b)
-    ) | meas_current  # Create an array of bool to act as a mask
+    diff_pairs_mask = np.array(
+        ((m != drv_a) & (m != drv_b) & (n != drv_a) & (n != drv_b)) | meas_current
+    )  # Create an array of bool to act as a mask
     arr = np.array([n, m]).T  # Create an array with n an m as columns
-    diff_pairs = arr[
-        ~np.array(diff_pairs_mask)
-    ]  # Remove elements not complying with the mask (eg: False)
-
+    # Remove elements not complying with the mask (eg: False)
+    # diff_pairs = arr[diff_pairs_mask] Removed inutile memory alloc
     # # build differential pairs
     # v = []
     # for a in range(i0, i0 + n_el):
@@ -474,7 +472,7 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
     #         # the order of m, n matters
     #         v.append([n, m])
     # diff_pairs = np.array(v)
-    return diff_pairs
+    return arr[diff_pairs_mask]
 
 
 def voltage_meter_nd(ex_mat, n_el=16, step=1, parser=None):

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -6,7 +6,8 @@
 # Distributed under the (new) BSD License. See LICENSE.txt for more info.
 from __future__ import division, absolute_import, print_function
 
-from collections import namedtuple
+from dataclasses import dataclass
+from typing import Union
 import numpy as np
 import numpy.linalg as la
 from scipy import sparse
@@ -14,10 +15,29 @@ from scipy import sparse
 from .utils import eit_scan_lines
 
 
+@dataclass
+class FwdResult:
+    """Summarize the PDE results from solving the fwd problem
+
+    Attributes
+    ----------
+    jac: np.ndarray
+        number of measures x n_E complex array, the Jacobian; shape(n_exc, n_el, n_tri)
+    v: np.ndarray
+        number of measures x 1 array, simulated boundary measures; shape(n_exc, n_el)
+    b_matrix: np.ndarray
+        back-projection mappings (smear matrix); shape(n_exc, n_pts, 1), dtype= bool
+    """
+
+    v: np.ndarray  # number of measures x 1 array, simulated boundary measures
+    jac: np.ndarray  # number of measures x n_E complex array, the Jacobian
+    b_matrix: np.ndarray  # back-projection mappings (smear matrix)
+
+
 class Forward:
     """FEM forward computing code"""
 
-    def __init__(self, mesh, el_pos):
+    def __init__(self, mesh: dict[str, np.ndarray], el_pos: np.ndarray) -> None:
         """
         A good FEM forward solver should only depend on
         mesh structure and the position of electrodes
@@ -26,7 +46,7 @@ class Forward:
         ----------
         mesh: dict
             mesh structure, {'node', 'element', 'perm'}
-        el_pos: NDArray
+        el_pos: np.ndarray
             numbering of electrodes positions
 
         Note
@@ -46,39 +66,54 @@ class Forward:
         # reference electrodes [ref node should not be on electrodes]
         ref_el = 0
         while ref_el in self.el_pos:
-            ref_el = ref_el + 1
+            ref_el += 1
         self.ref = ref_el
 
         # infer dimensions from mesh
         self.n_pts, self.n_dim = self.pts.shape
         self.n_tri, self.n_vertices = self.tri.shape
-        self.ne = el_pos.size
+        self.n_el = el_pos.size
 
-    def solve_eit(self, ex_mat=None, step=1, perm=None, parser=None, vector=False):
+    def solve_eit(
+        self,
+        ex_mat: np.ndarray = None,
+        step: int = 1,
+        perm: np.ndarray = None,
+        parser: Union[str, list[str]] = None,
+        **kwargs,
+    ) -> FwdResult:
         """
         EIT simulation, generate perturbation matrix and forward v
 
         Parameters
         ----------
-        ex_mat: NDArray
+        ex_mat: np.ndarray
             numLines x n_el array, stimulation matrix
         step: int
-            the configuration of measurement electrodes (default: adjacent)
-        perm: NDArray
+            the configuration of measurement electrodes (default: apposition)
+        perm: np.ndarray
             Mx1 array, initial x0. must be the same size with self.tri_perm
         parser: str
             see voltage_meter for more details.
-        vector: bool, optional
-            Use vectorized methods or regular methods, for compatibility.
 
         Returns
         -------
-        jac: NDArray
+        fwd_results: FwdResult
+            PDE results from solving the fwd problem (see `FwdResult`)
+
+        Note
+        ----
+        Single PDE results are:
+        - fwd_results.jac: np.ndarray
             number of measures x n_E complex array, the Jacobian
-        v: NDArray
+        - fwd_results.v: np.ndarray
             number of measures x 1 array, simulated boundary measures
-        b_matrix: NDArray
+        - fwd_results.b_matrix: np.ndarray
             back-projection mappings (smear matrix)
+
+        (see `FwdResult` for more details)
+
+
         """
         # initialize/extract the scan lines (default: apposition)
         if ex_mat is None:
@@ -93,193 +128,121 @@ class Forward:
             assert perm.shape == (self.n_tri,)
             perm0 = perm
 
-        def vectorization():
-            """
-            Vectorized methods.
-            """
-            f, jac_i = self.solve_nd(ex_mat, perm0)
-            f_el = f[:, self.el_pos]
-
-            # boundary measurements, subtract_row-voltages on electrodes
-            diff_op = voltage_meter_nd(
-                ex_mat, n_el=self.ne, step=step, parser=parser
-            ).astype(int)
-            v = subtract_row_nd(f_el, diff_op)
-            jac = subtract_row_nd(jac_i, diff_op)
-
-            # build bp projection matrix
-            # 1. we can either smear at the center of elements, using
-            #    >> fe = np.mean(f[:, self.tri], axis=1)
-            # 2. or, simply smear at the nodes using f
-            b_matrix = smear_nd(f, f_el, diff_op)
-            return v, jac, b_matrix
-
-        def no_vectorization():
-            """
-            Standard methods.
-            """
-            # calculate f and Jacobian iteratively over all stimulation lines
-            jac, v, b_matrix = [], [], []
-            n_lines = ex_mat.shape[0]
-            for i in range(n_lines):
-                # FEM solver of one stimulation pattern, a row in ex_mat
-                ex_line = ex_mat[i]
-                f, jac_i = self.solve(ex_line, perm0)
-                f_el = f[self.el_pos]
-
-                # boundary measurements, subtract_row-voltages on electrodes
-                diff_op = voltage_meter(ex_line, n_el=self.ne, step=step, parser=parser)
-                v_diff = subtract_row(f_el, diff_op)
-                jac_diff = subtract_row(jac_i, diff_op)
-
-                # build bp projection matrix
-                # 1. we can either smear at the center of elements, using
-                #    >> fe = np.mean(f[self.tri], axis=1)
-                # 2. or, simply smear at the nodes using f
-                b = smear(f, f_el, diff_op)
-
-                # append
-                v.append(v_diff)
-                jac.append(jac_diff)
-                b_matrix.append(b)
-            return v, jac, b_matrix
-
+        f, jac_i = self.solve(ex_mat, perm0)
+        f_el = f[:, self.el_pos]
+        # boundary measurements, subtract_row-voltages on electrodes
+        diff_op = voltage_meter(ex_mat, n_el=self.n_el, step=step, parser=parser)
+        v = subtract_row(f_el, diff_op)
+        jac = subtract_row(jac_i, diff_op)
+        # build bp projection matrix
+        # 1. we can either smear at the center of elements, using
+        #    >> fe = np.mean(f[:, self.tri], axis=1)
+        # 2. or, simply smear at the nodes using f
+        b_matrix = smear(
+            f, f_el, diff_op, new=True
+        )  # set new to `False` to get computation from ChabaneAmaury
         # update output, now you can call p.jac, p.v, p.b_matrix
-        if vector:
-            v, jac, b_matrix = vectorization()
+        return FwdResult(
+            jac=np.vstack(jac), v=np.hstack(v), b_matrix=np.vstack(b_matrix)
+        )
+
+    def solve(
+        self, ex_mat: np.ndarray, perm: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Calculate and compute the potential distribution (complex-valued)
+        corresponding to the permittivity distribution `perm ` for all
+        excitations contained in the excitation pattern `ex_mat`
+
+        The calculation of Jacobian can be skipped.
+        Currently, only simple electrode model is supported,
+        CEM (complete electrode model) is under development.
+
+        Parameters
+        ----------
+        ex_mat: np.ndarray
+            stimulation/excitation matrix ; shape (n_exc, 2)
+        perm: np.ndarray
+            permittivity on elements (initial) ; shape (n_tri,)
+
+        Returns
+        -------
+        f: np.ndarray
+            potential on nodes ; shape (n_exc, n_pts)
+        jac: np.ndarray
+            Jacobian ; shape (n_exc, n_el, n_tri)
+
+        Notes
+        -------
+        For compatibility with some scripts in /examples a single excitation
+        line can be passed instead of the whole excitation pattern `ex_mat`
+        (e.g. [0,7] or np.array([0,7]) or ex_mat[0].ravel). In that case a
+        simplified version of `f` with shape (n_pts,) and of
+        `jac` with shape (n_el, n_tri) are returned
+        """
+        # case ex_line has been passed instead of ex_mat
+        if isinstance(ex_mat, list) and len(ex_mat) == 2:
+            ex_mat = np.array([ex_mat]).reshape((1, 2))  # build a 2D array
+        elif isinstance(ex_mat, np.ndarray) and ex_mat.ndim == 1:
+            ex_mat = ex_mat.reshape((-1, 2))
+        elif (
+            isinstance(ex_mat, np.ndarray) and ex_mat.ndim == 2 and ex_mat.shape[1] == 2
+        ):
+            pass  # correct value
         else:
-            v, jac, b_matrix = no_vectorization()
+            raise TypeError(
+                f"Wrong value of {ex_mat=} expected an ndarray ; shape (n_exc, 2)"
+            )
 
-        pde_result = namedtuple("pde_result", ["jac", "v", "b_matrix"])
-        p = pde_result(jac=np.vstack(jac), v=np.hstack(v), b_matrix=np.vstack(b_matrix))
-        return p
-
-    def solve(self, ex_line, perm):
-        """
-        with one pos (A), neg(B) driven pairs, calculate and
-        compute the potential distribution (complex-valued)
-
-        The calculation of Jacobian can be skipped.
-        Currently, only simple electrode model is supported,
-        CEM (complete electrode model) is under development.
-
-        Parameters
-        ----------
-        ex_line: NDArray
-            stimulation (scan) patterns/lines
-        perm: NDArray
-            permittivity on elements (initial)
-
-        Returns
-        -------
-        f: NDArray
-            potential on nodes
-        J: NDArray
-            Jacobian
-        """
         # 1. calculate local stiffness matrix (on each element)
         ke = calculate_ke(self.pts, self.tri)
 
         # 2. assemble to global K
-        kg = assemble_sparse(ke, self.tri, perm, self.n_pts, ref=self.ref)
+        kg = assemble(ke, self.tri, perm, self.n_pts, ref=self.ref)
 
         # 3. calculate electrode impedance matrix R = K^{-1}
         r_matrix = la.inv(kg)
         r_el = r_matrix[self.el_pos]
 
         # 4. solving nodes potential using boundary conditions
-        b = self._natural_boundary(ex_line)
-        f = np.dot(r_matrix, b).ravel()
-
-        # 5. build Jacobian matrix column wise (element wise)
-        #    Je = Re*Ke*Ve = (nex3) * (3x3) * (3x1)
-        jac = np.zeros((self.ne, self.n_tri), dtype=perm.dtype)
-        for (i, e) in enumerate(self.tri):
-            jac[:, i] = np.dot(np.dot(r_el[:, e], ke[i]), f[e])
-
-        return f, jac
-
-    def solve_nd(self, ex_mat, perm):
-        """
-        Vectorized version of solve. It take the full ex_mat
-        instead of lines.
-
-        with one pos (A), neg(B) driven pairs, calculate and
-        compute the potential distribution (complex-valued)
-
-        The calculation of Jacobian can be skipped.
-        Currently, only simple electrode model is supported,
-        CEM (complete electrode model) is under development.
-
-        Parameters
-        ----------
-        ex_mat: NDArray
-            stimulation (scan) patterns/lines
-        perm: NDArray
-            permittivity on elements (initial)
-
-        Returns
-        -------
-        f: NDArray
-            potential on nodes
-        J: NDArray
-            Jacobian
-        """
-        # 1. calculate local stiffness matrix (on each element)
-        ke = calculate_ke(self.pts, self.tri)
-
-        # 2. assemble to global K
-        kg = assemble_sparse(ke, self.tri, perm, self.n_pts, ref=self.ref)
-
-        # 3. calculate electrode impedance matrix R = K^{-1}
-        r_matrix = la.inv(kg)
-        r_el = r_matrix[self.el_pos]
-
-        # 4. solving nodes potential using boundary conditions
-        b = self._natural_boundary_nd(ex_mat)
+        b = self._natural_boundary(ex_mat)
 
         f = np.dot(r_matrix, b[:, None]).T.reshape(b.shape[:-1])
 
         # 5. build Jacobian matrix column wise (element wise)
         #    Je = Re*Ke*Ve = (nex3) * (3x3) * (3x1)
-        jac = np.zeros((ex_mat.shape[0], self.ne, self.n_tri), dtype=perm.dtype)
+        jac = np.zeros((ex_mat.shape[0], self.n_el, self.n_tri), dtype=perm.dtype)
 
         def jac_init(jac, k):
             for (i, e) in enumerate(self.tri):
                 jac[:, i] = np.dot(np.dot(r_el[:, e], ke[i]), f[k, e])
             return jac
 
-        jac = np.array(list(map(jac_init, jac, np.arange(0, ex_mat.shape[0]))))
+        jac = np.array(list(map(jac_init, jac, np.arange(ex_mat.shape[0]))))
+
+        # case ex_line has been passed instead of ex_mat
+        # we return simplified version of f with shape (n_pts,) and jac with shape (ne, n_tri)
+        if ex_mat.shape[0] == 1:
+            return f[0, :].ravel(), jac[0, :, :]
 
         return f, jac
 
-    def _natural_boundary(self, ex_line):
+    def _natural_boundary(self, ex_mat: np.ndarray) -> np.ndarray:
         """
-        Notes
-        -----
-        Generate the Neumann boundary condition. In utils.py,
-        you should note that ex_line is local indexed from 0...15,
+        Generate the Neumann boundary condition.
+
+        In utils.py, you should note that ex_mat is local indexed from 0...15,
         which need to be converted to global node number using el_pos.
-        """
-        drv_a_global = self.el_pos[ex_line[0]]
-        drv_b_global = self.el_pos[ex_line[1]]
 
-        # global boundary condition
-        b = np.zeros((self.n_pts, 1))
-        b[drv_a_global] = 1.0
-        b[drv_b_global] = -1.0
+        Parameters
+        ----------
+        ex_mat: np.ndarray
+            stimulation/excitation matrix ; shape (n_exc, 2)
 
-        return b
-
-    def _natural_boundary_nd(self, ex_mat):
-        """
-        Notes
-        -----
-        Same as _natural_boundary, except it takes advantage of
-        Numpy's vectorization capacities.
-        Generate the Neumann boundary condition. In utils.py,
-        you should note that ex_line is local indexed from 0...15,
-        which need to be converted to global node number using el_pos.
+        Returns
+        ----------
+        b: np.ndarray
+            Global boundary condition on pts ; shape (n_exc, n_pts, 1)
         """
         drv_a_global = self.el_pos[ex_mat[:, 0]]
         drv_b_global = self.el_pos[ex_mat[:, 1]]
@@ -292,114 +255,120 @@ class Forward:
         return b
 
 
-def smear(f, fb, pairs):
+def _smear(f: np.ndarray, fb: np.ndarray, pairs: np.ndarray) -> np.ndarray:
     """
-    build smear matrix B for bp
+    Build smear matrix B for bp for one exitation
 
     Parameters
     ----------
-    f: NDArray
+    f: np.ndarray
         potential on nodes
-    fb: NDArray
+    fb: np.ndarray
         potential on adjacent electrodes
-    pairs: NDArray
+    pairs: np.ndarray
         electrodes numbering pairs
 
     Returns
     -------
-    B: NDArray
+    B: np.ndarray
         back-projection matrix
     """
-
     # Replacing the code below by a faster implementation in Numpy
-    f_min, f_max = np.minimum(fb[pairs[:, 0]], fb[pairs[:, 1]]).reshape(
-        (-1, 1)
-    ), np.maximum(fb[pairs[:, 0]], fb[pairs[:, 1]]).reshape((-1, 1))
-    b_matrix = (f_min < f) & (f <= f_max)
-
-    # b_matrix = []
-    # for i, j in pairs:
-    #     f_min, f_max = min(fb[i], fb[j]), max(fb[i], fb[j])
-    #     b_matrix.append((f_min < f) & (f <= f_max))
-    # return np.array(b_matrix)
-    return b_matrix
+    f_min = np.minimum(fb[pairs[:, 0]], fb[pairs[:, 1]]).reshape((-1, 1))
+    f_max = np.maximum(fb[pairs[:, 0]], fb[pairs[:, 1]]).reshape((-1, 1))
+    return (f_min < f) & (f <= f_max)
 
 
-def smear_nd(f, fb, pairs):
+def smear(
+    f: np.ndarray, fb: np.ndarray, meas_pattern: np.ndarray, new: bool = False
+) -> np.ndarray:
     """
-    Same as smear, except it takes advantage of
-    Numpy's vectorization capacities.
-    build smear matrix B for bp
+    Build smear matrix B for bp
 
     Parameters
     ----------
-    f: NDArray
-        potential on nodes
-    fb: NDArray
-        potential on adjacent electrodes
-    pairs: NDArray
-        electrodes numbering pairs
+    f: np.ndarray
+        potential on nodes; shape (n_exc, n_pts)
+    fb: np.ndarray
+        potential on adjacent electrodes; shape (n_exc, n_el)
+    meas_pattern: np.ndarray
+        electrodes numbering pairs; shape (n_exc, n_meas, 2)
 
     Returns
     -------
-    B: NDArray
-        back-projection matrix
+    B: np.ndarray
+        back-projection matrix; shape (n_exc, n_meas, n_pts), dtype= bool
     """
+    if new:
+        # new implementation not much faster! :(
+        idx_meas_0 = meas_pattern[:, :, 0]
+        idx_meas_1 = meas_pattern[:, :, 1]
+        n_exc = meas_pattern.shape[0]  # number of excitations
+        n_meas = meas_pattern.shape[1]  # number of measurements per excitations
+        n_pts = f.shape[1]  # number of nodes
+        idx_exc = np.ones_like(idx_meas_0, dtype=int) * np.arange(n_exc).reshape(
+            n_exc, 1
+        )
+        f_min = np.minimum(fb[idx_exc, idx_meas_0], fb[idx_exc, idx_meas_1])
+        f_max = np.maximum(fb[idx_exc, idx_meas_0], fb[idx_exc, idx_meas_1])
+        # contruct matrices of shapes (n_exc, n_meas, n_pts) for comparison
+        f_min = np.repeat(f_min[:, :, np.newaxis], n_pts, axis=2)
+        f_max = np.repeat(f_max[:, :, np.newaxis], n_pts, axis=2)
+        f0 = np.repeat(f[:, :, np.newaxis], n_meas, axis=2)
+        f0 = f0.swapaxes(1, 2)
+        return (f_min < f0) & (f0 <= f_max)
+    else:
+        # Replacing the below code by a faster implementation in Numpy
+        def b_matrix_init(k):
+            return _smear(f[k], fb[k], meas_pattern[k])
 
-    # Replacing the below code by a faster implementation in Numpy
-    def b_matrix_init(k):
-        return smear(f[k], fb[k], pairs[k])
-
-    return np.array(list(map(b_matrix_init, np.arange(0, f.shape[0]))))
+        return np.array(list(map(b_matrix_init, np.arange(f.shape[0]))))
 
 
-def subtract_row(v, pairs):
+def subtract_row(v: np.ndarray, meas_pattern: np.ndarray) -> np.ndarray:
     """
+    Build the voltage differences using the meas_pattern.
     v_diff[k] = v[i, :] - v[j, :]
 
-    Parameters
-    ----------
-    v: NDArray
-        Nx1 boundary measurements vector or NxM matrix
-    pairs: NDArray
-        Nx2 subtract_row pairs
-
-    Returns
-    -------
-    v_diff: NDArray
-        difference measurements
-    """
-    return v[pairs[:, 0]] - v[pairs[:, 1]]
-
-
-def subtract_row_nd(v, pairs):
-    """
-    Same as subtract_row, except it takes advantage of
-    Numpy's vectorization capacities.
-    v_diff[k] = v[i, :] - v[j, :]
+    New implementation 33% less computation time
 
     Parameters
     ----------
-    v: NDArray
-        Nx1 boundary measurements vector or NxM matrix
-    pairs: NDArray
-        Nx2 subtract_row pairs
+    v: np.ndarray
+        Nx1 boundary measurements vector or NxM matrix; shape (n_exc,n_el,1)
+    meas_pattern: np.ndarray
+        Nx2 subtract_row pairs; shape (n_exc, n_meas, 2)
 
     Returns
     -------
-    v_diff: NDArray
+    v_diff: np.ndarray
         difference measurements
     """
 
-    def v_diff_init(k):
-        return subtract_row(v[k], pairs[k])
+    if v.shape[:1] != meas_pattern.shape[:1]:
+        raise ValueError(
+            f"Measurements vector v ({v.shape=}) should have same 1stand 2nd dim as meas_pattern ({meas_pattern.shape=})"
+        )
 
-    return np.array(list(map(v_diff_init, np.arange(0, v.shape[0]))))
+    # creation of excitation indexe for each idx_meas
+    idx_meas_0 = meas_pattern[:, :, 0]
+    idx_meas_1 = meas_pattern[:, :, 1]
+    n_exc = meas_pattern.shape[0]
+    idx_exc = np.ones_like(idx_meas_0, dtype=int) * np.arange(n_exc).reshape(n_exc, 1)
+
+    return v[idx_exc, idx_meas_0] - v[idx_exc, idx_meas_1]
 
 
-def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
+def voltage_meter(
+    ex_mat: np.ndarray,
+    n_el: int = 16,
+    step: int = 1,
+    parser: Union[str, list[str]] = None,
+) -> np.ndarray:
     """
-    extract subtract_row-voltage measurements on boundary electrodes.
+    Build the measurement pattern (subtract_row-voltage pairs [N, M])
+    for all excitations on boundary electrodes.
+
     we direct operate on measurements or Jacobian on electrodes,
     so, we can use LOCAL index in this module, do not require el_pos.
 
@@ -412,13 +381,13 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
 
     Parameters
     ----------
-    ex_line: NDArray
-        2x1 array, [positive electrode, negative electrode].
+    ex_mat: np.ndarray
+        Nx2 array, [positive electrode, negative electrode]. ; shape (n_exc, 2)
     n_el: int
         number of total electrodes.
     step: int
         measurement method (two adjacent electrodes are used for measuring).
-    parser: str or list[str]
+    parser: str | list[str]
         if parser contains 'fmmu', or 'rotate_meas' then data are trimmed,
         boundary voltage measurements are re-indexed and rotated,
         start from the positive stimulus electrode start index 'A'.
@@ -430,182 +399,49 @@ def voltage_meter(ex_line, n_el=16, step=1, parser=None) -> np.ndarray:
 
     Returns
     -------
-    v: NDArray
-        (N-1)*2 arrays of subtract_row pairs
+    meas_pattern : np.ndarray
+        subtract_row pairs [N, M]; shape (n_exc, n_meas_per_exc, 2)
     """
     # local node
-    drv_a = ex_line[0]
-    drv_b = ex_line[1]
-
-    if not isinstance(parser, list):  # transform parser in list
-        parser = [parser]
-
-    meas_current = (
-        "meas_current" in parser
-    )  # flag for measurements on current carrying electrodes
-    fmmu_rotate = any(p in ("fmmu", "rotate_meas") for p in parser)
-    i0 = drv_a if fmmu_rotate else 0
-
-    # Same code as below but with numpy implementation for faster computing
-    # build differential pairs
-    a = np.arange(i0, i0 + n_el)
-    m = a % n_el
-    n = (m + step) % n_el
-    # if any of the electrodes is the stimulation electrodes
-    diff_pairs_mask = np.array(
-        ((m != drv_a) & (m != drv_b) & (n != drv_a) & (n != drv_b)) | meas_current
-    )  # Create an array of bool to act as a mask
-    arr = np.array([n, m]).T  # Create an array with n an m as columns
-    # Remove elements complying with the mask (eg: True)
-    # diff_pairs = arr[diff_pairs_mask] Removed inutile memory alloc
-    # # build differential pairs
-    # v = []
-    # for a in range(i0, i0 + n_el):
-    #     m = a % n_el
-    #     n = (m + step) % n_el
-    #     # if any of the electrodes is the stimulation electrodes
-    #     if not (m == drv_a or m == drv_b or n == drv_a or n == drv_b) or meas_current:
-    #         # the order of m, n matters
-    #         v.append([n, m])
-    # diff_pairs = np.array(v)
-    return arr[diff_pairs_mask]
-
-
-def voltage_meter_nd(ex_mat, n_el=16, step=1, parser=None):
-    """
-    Faster implementation using numpy's native ufuncs.
-    Made to work with a full matrix, unlike voltage_meter.
-
-    extract subtract_row-voltage measurements on boundary electrodes.
-    we direct operate on measurements or Jacobian on electrodes,
-    so, we can use LOCAL index in this module, do not require el_pos.
-
-    Notes
-    -----
-    ABMN Model.
-    A: current driving electrode,
-    B: current sink,
-    M, N: boundary electrodes, where v_diff = v_n - v_m.
-
-    Parameters
-    ----------
-    ex_line: NDArray
-        2x1 array, [positive electrode, negative electrode].
-    n_el: int
-        number of total electrodes.
-    step: int
-        measurement method (two adjacent electrodes are used for measuring).
-    parser: str or list[str]
-        if parser contains 'fmmu', or 'rotate_meas' then data are trimmed,
-        boundary voltage measurements are re-indexed and rotated,
-        start from the positive stimulus electrode start index 'A'.
-        if parser contains 'std', or 'no_rotate_meas' then data are trimmed,
-        the start index (i) of boundary voltage measurements is always 0.
-        if parser contains 'meas_current', the measurements on current carrying
-        electrodes are allowed. Otherwise the measurements on current carrying
-        electrodes are discarded (like 'no_meas_current' option in EIDORS3D).
-
-    Returns
-    -------
-    v: NDArray
-        (N-1)*2 arrays of subtract_row pairs
-    """
-    # local node
-    drv_a = ex_mat[:, 0]
-    drv_b = ex_mat[:, 1]
+    ex_mat = ex_mat.astype(int)
+    n_exc = ex_mat.shape[0]
+    drv_a = np.ones((n_exc, n_exc), dtype=int) * ex_mat[:, 0].reshape(n_exc, 1)
+    drv_b = np.ones((n_exc, n_exc), dtype=int) * ex_mat[:, 1].reshape(n_exc, 1)
 
     if not isinstance(parser, list):  # transform parser in list
         parser = [parser]
 
     meas_current = "meas_current" in parser
     fmmu_rotate = any(p in ("fmmu", "rotate_meas") for p in parser)
-    i0 = drv_a if fmmu_rotate else np.zeros(shape=drv_a.shape)
+    i0 = drv_a if fmmu_rotate else np.zeros_like(drv_a)
 
-    # Same code as below but with numpy implementation for faster computing
-    # build differential pairs
-    a = np.array([np.arange(i0[i], i0[i] + n_el) for i in range(i0.shape[0])])
-    m = a % n_el
+    idx_el = np.ones((n_exc, n_el), dtype=int) * np.arange(n_el)
+    m = (i0 + idx_el) % n_el
     n = (m + step) % n_el
-    # if any of the electrodes is the stimulation electrodes
-    diff_pairs_mask = np.array(
-        [
-            (
-                (
-                    (m[i] != drv_a[i])
-                    & (m[i] != drv_b[i])
-                    & (n[i] != drv_a[i])
-                    & (n[i] != drv_b[i])
-                )
-                | meas_current
-            )
-            for i in range(m.shape[0])
-        ]
+    meas_pattern = np.concatenate((n[:, :, np.newaxis], m[:, :, np.newaxis]), 2)
+
+    if meas_current:
+        return meas_pattern
+
+    diff_pairs_mask = np.logical_and.reduce(
+        (m != drv_a, m != drv_b, n != drv_a, n != drv_b)
     )
-    arr = np.array([np.array([n[i], m[i]]).T for i in range(n.shape[0])])
-    return np.array(
-        [arr[i, np.array((diff_pairs_mask[i]))] for i in range(arr.shape[0])]
-    )
+    return meas_pattern[diff_pairs_mask].reshape(n_exc, -1, 2)
 
 
-def assemble(ke, tri, perm, n_pts, ref=0):
-    """
-    Assemble the stiffness matrix (dense matrix, default)
-
-    Parameters
-    ----------
-    ke: NDArray
-        n_tri x (n_dim x n_dim) 3d matrix
-    tri: NDArray
-        the structure of mesh
-    perm: NDArray
-        n_tri x 1 conductivities on elements
-    n_pts: int
-        number of nodes
-    ref: int
-        reference electrode
-
-    Returns
-    -------
-    K: NDArray
-        k_matrix, NxN array of complex stiffness matrix
-
-    Notes
-    -----
-    you can use sparse matrix (IJV) format to automatically add the local
-    stiffness matrix to the global matrix.
-    """
-    n_tri = tri.shape[0]
-
-    # assemble global stiffness matrix
-    k_global = np.zeros((n_pts, n_pts), dtype=perm.dtype)
-    for ei in range(n_tri):
-        k_local = ke[ei]
-        pe = perm[ei]
-
-        no = tri[ei, :]
-        ij = np.ix_(no, no)
-        k_global[ij] += k_local * pe
-
-    # place reference electrode
-    if 0 <= ref < n_pts:
-        k_global[ref, :] = 0.0
-        k_global[:, ref] = 0.0
-        k_global[ref, ref] = 1.0
-
-    return k_global
-
-
-def assemble_sparse(ke, tri, perm, n_pts, ref=0):
+def assemble(
+    ke: np.ndarray, tri: np.ndarray, perm: np.ndarray, n_pts: int, ref: int = 0
+) -> np.ndarray:
     """
     Assemble the stiffness matrix (using sparse matrix)
 
     Parameters
     ----------
-    ke: NDArray
+    ke: np.ndarray
         n_tri x (n_dim x n_dim) 3d matrix
-    tri: NDArray
+    tri: np.ndarray
         the structure of mesh
-    perm: NDArray
+    perm: np.ndarray
         n_tri x 1 conductivities on elements
     n_pts: int
         number of nodes
@@ -614,8 +450,8 @@ def assemble_sparse(ke, tri, perm, n_pts, ref=0):
 
     Returns
     -------
-    K: NDArray
-        k_matrix, NxN array of complex stiffness matrix
+    K: np.ndarray
+        NxN array of complex stiffness matrix
 
     Notes
     -----
@@ -641,34 +477,36 @@ def assemble_sparse(ke, tri, perm, n_pts, ref=0):
     # data = mask_ref_node(data, row, col, ref)
 
     # for efficient sparse inverse (csc)
-    A = sparse.csr_matrix((data, (row, col)), shape=(n_pts, n_pts), dtype=perm.dtype)
+    k_matrix = sparse.csr_matrix(
+        (data, (row, col)), shape=(n_pts, n_pts), dtype=perm.dtype
+    )
 
     # the stiffness matrix may not be sparse
-    A = A.toarray()
+    k_matrix = k_matrix.toarray()
 
     # place reference electrode
     if 0 <= ref < n_pts:
-        A[ref, :] = 0.0
-        A[:, ref] = 0.0
-        A[ref, ref] = 1.0
+        k_matrix[ref, :] = 0.0
+        k_matrix[:, ref] = 0.0
+        k_matrix[ref, ref] = 1.0
 
-    return A
+    return k_matrix
 
 
-def calculate_ke(pts, tri):
+def calculate_ke(pts: np.ndarray, tri: np.ndarray) -> np.ndarray:
     """
     Calculate local stiffness matrix on all elements.
 
     Parameters
     ----------
-    pts: NDArray
+    pts: np.ndarray
         Nx2 (x,y) or Nx3 (x,y,z) coordinates of points
-    tri: NDArray
+    tri: np.ndarray
         Mx3 (triangle) or Mx4 (tetrahedron) connectivity of elements
 
     Returns
     -------
-    ke_array: NDArray
+    ke_array: np.ndarray
         n_tri x (n_dim x n_dim) 3d matrix
     """
     n_tri, n_vertices = tri.shape
@@ -696,57 +534,52 @@ def calculate_ke(pts, tri):
     return ke_array
 
 
-def _k_triangle(xy):
+def _k_triangle(xy: np.ndarray) -> np.ndarray:
     """
     given a point-matrix of an element, solving for Kij analytically
     using barycentric coordinates (simplex coordinates)
 
     Parameters
     ----------
-    xy: NDArray
+    xy: np.ndarray
         (x,y) of nodes 1,2,3 given in counterclockwise manner
 
     Returns
     -------
-    ke_matrix: NDArray
+    ke_matrix: np.ndarray
         local stiffness matrix
     """
     # edges (vector) of triangles
     s = xy[[2, 0, 1]] - xy[[1, 2, 0]]
-    # s1 = xy[2, :] - xy[1, :]
-    # s2 = xy[0, :] - xy[2, :]
-    # s3 = xy[1, :] - xy[0, :]
 
     # area of triangles. Note, abs is removed since version 2020,
     # user must make sure all triangles are CCW (conter clock wised).
-    # at = 0.5 * la.det(s[[0, 1]])
     at = 0.5 * det2x2(s[0], s[1])
+    # TODO maybe replace with:
+    # at= 0.5 * np.linalg.det(s)
 
-    # (e for element) local stiffness matrix
-    ke_matrix = np.dot(s, s.T) / (4.0 * at)
-
-    return ke_matrix
+    # Local stiffness matrix (e for element)
+    return np.dot(s, s.T) / (4.0 * at)
 
 
-def det2x2(s1, s2):
+def det2x2(s1: np.ndarray, s2: np.ndarray) -> float:
     """Calculate the determinant of a 2x2 matrix"""
     return s1[0] * s2[1] - s1[1] * s2[0]
 
 
-def _k_tetrahedron(xy):
+def _k_tetrahedron(xy: np.ndarray) -> np.ndarray:
     """
-    given a point-matrix of an element, solving for Kij analytically
+    Given a point-matrix of an element, solving for Kij analytically
     using barycentric coordinates (simplex coordinates)
 
     Parameters
     ----------
-    xy: NDArray
-        (x,y) of nodes 1, 2, 3, 4 given in counterclockwise manner,
-        see notes.
+    xy: np.ndarray
+        (x,y) of nodes 1, 2, 3, 4 given in counterclockwise manner, see notes.
 
     Returns
     -------
-    ke_matrix: NDArray
+    ke_matrix: np.ndarray
         local stiffness matrix
 
     Notes
@@ -765,10 +598,11 @@ def _k_tetrahedron(xy):
     # re-normalize using alternative (+,-) signs
     ij_pairs = [[0, 1], [1, 2], [2, 3], [3, 0]]
     signs = [1, -1, 1, -1]
-    a = [sign * np.cross(s[i], s[j]) for (i, j), sign in zip(ij_pairs, signs)]
-    a = np.array(a)
+    a = np.array([sign * np.cross(s[i], s[j]) for (i, j), sign in zip(ij_pairs, signs)])
 
     # local (e for element) stiffness matrix
-    ke_matrix = np.dot(a, a.transpose()) / (36.0 * vt)
+    return np.dot(a, a.transpose()) / (36.0 * vt)
 
-    return ke_matrix
+
+if __name__ == "__main__":
+    """"""

--- a/pyeit/eit/greit.py
+++ b/pyeit/eit/greit.py
@@ -72,7 +72,11 @@ class GREIT(EitBase):
         lamb, p = self.params["lamb"], self.params["p"]
 
         f = self.fwd.solve_eit(
-            self.ex_mat, step=self.step, perm=self.perm, parser=self.parser
+            self.ex_mat,
+            step=self.step,
+            perm=self.perm,
+            parser=self.parser,
+            vector=self.vector,
         )
         jac = f.jac
         # E[yy^T], it is more efficient to use left pinv than right pinv

--- a/pyeit/eit/greit.py
+++ b/pyeit/eit/greit.py
@@ -76,7 +76,6 @@ class GREIT(EitBase):
             step=self.step,
             perm=self.perm,
             parser=self.parser,
-            vector=self.vector,
         )
         jac = f.jac
         # E[yy^T], it is more efficient to use left pinv than right pinv

--- a/pyeit/eit/jac.py
+++ b/pyeit/eit/jac.py
@@ -78,7 +78,7 @@ class JAC(EitBase):
         lamb_min=0,
         method="kotre",
         verbose=False,
-        vector=None,
+        **kwargs,
     ):
         """
         Gaussian Newton Static Solver
@@ -102,8 +102,6 @@ class JAC(EitBase):
             'kotre' or 'lm'
         verbose: bool, optional
             print debug information
-        vector: bool, optional
-            Use vectorized methods or regular methods, for compatibility.
 
         Returns
         -------
@@ -126,8 +124,6 @@ class JAC(EitBase):
             lamb = self.params["lamb"]
         if method is None:
             method = self.params["method"]
-        if vector is None:
-            vector = self.vector
 
         # convergence test
         x0_norm = np.linalg.norm(x0)
@@ -136,7 +132,7 @@ class JAC(EitBase):
 
             # forward solver
             fs = self.fwd.solve_eit(
-                self.ex_mat, step=self.step, perm=x0, parser=self.parser, vector=vector
+                self.ex_mat, step=self.step, perm=x0, parser=self.parser
             )
             # Residual
             r0 = v - fs.v

--- a/pyeit/eit/jac.py
+++ b/pyeit/eit/jac.py
@@ -78,7 +78,7 @@ class JAC(EitBase):
         lamb_min=0,
         method="kotre",
         verbose=False,
-        vector=False,
+        vector=None,
     ):
         """
         Gaussian Newton Static Solver
@@ -126,6 +126,8 @@ class JAC(EitBase):
             lamb = self.params["lamb"]
         if method is None:
             method = self.params["method"]
+        if vector is None:
+            vector = self.vector
 
         # convergence test
         x0_norm = np.linalg.norm(x0)

--- a/pyeit/eit/utils.py
+++ b/pyeit/eit/utils.py
@@ -11,52 +11,39 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 
 
-def eit_scan_lines(ne=16, dist=1):
+def eit_scan_lines(n_el: int = 16, dist: int = 1) -> np.ndarray:
     """
-    generate scan matrix
+    Generate scan matrix, `ex_mat` ( or excitation pattern), see notes
 
-    Parameters
-    ----------
-    ne: int
-        number of electrodes
-    dist: int
-        distance between A and B (default=1)
+    Args:
+        n_el (int, optional): number of electrodes. Defaults to `16`.
+        dist (int, optional): distance (number of electrodes) of A to B. Defaults to `1`.
+        For 'adjacent'- or 'neighbore'-mode (default) use `1` , and
+        for 'apposition'-mode use `n_el/2`, (see Examples)
 
-    Returns
-    -------
-    ex_mat: NDArray
-        stimulation matrix
+    Returns:
+        np.ndarray: stimulation matrix; shape (n_exc, 2)
 
-    Notes
-    -----
-    in the scan of EIT (or stimulation matrix), we use 4-electrodes
-    mode, where A, B are used as positive and negative stimulation
-    electrodes and M, N are used as voltage measurements
+    Notes:
+        - in the scan of EIT (or stimulation matrix), we use 4-electrodes
+        mode, where A, B are used as positive and negative stimulation
+        electrodes and M, N are used as voltage measurements.
+        - `1` (A) for positive current injection, `-1` (B) for negative current
+        sink
 
-    1 (A) for positive current injection,
-    -1 (B) for negative current sink
+    Examples:
+        n_el=16
+        if mode=='neighbore':
+            ex_mat = eit_scan_lines(n_el=n_el)
+        elif mode=='apposition':
+            ex_mat = eit_scan_lines(dist=n_el/2)
 
-    dist is the distance (number of electrodes) of A to B
-    in 'adjacent' mode, dist=1, in 'apposition' mode, dist=ne/2
-
-    Examples
-    --------
-    # let the number of electrodes, ne=16
-
-    if mode=='neighbore':
-        ex_mat = eit_scan_lines()
-    elif mode=='apposition':
-        ex_mat = eit_scan_lines(dist=8)
-
-    WARNING
-    -------
-    ex_mat is a local index, where it is ranged from 0...15, within the range
-    of the number of electrodes. In FEM applications, you should convert ex_mat
-    to global index using the (global) el_pos parameters.
+    WARNING:
+        `ex_mat` is a local index, where it is ranged from 0...15, within the
+        range of the number of electrodes. In FEM applications, you should
+        convert `ex_mat` to global index using the (global) `el_pos` parameters.
     """
-    ex = np.array([[i, np.mod(i + dist, ne)] for i in range(ne)])
-
-    return ex
+    return np.array([[i, np.mod(i + dist, n_el)] for i in range(n_el)])
 
 
 if __name__ == "__main__":

--- a/pyeit/mesh/wrapper.py
+++ b/pyeit/mesh/wrapper.py
@@ -83,7 +83,7 @@ def create(n_el=16, fd=None, fh=shape.area_uniform, h0=0.1, p_fix=None, bbox=Non
     # 3. generate electrodes, the same as p_fix (top n_el)
     el_pos = np.arange(n_el)
     # 4. init uniform element permittivity (sigma)
-    perm = np.ones(t.shape[0], dtype=np.float)
+    perm = np.ones(t.shape[0], dtype=float)  # np.float is deprecated
     # 5. build output structure
     mesh = {"element": t, "node": p, "perm": perm}
     return mesh, el_pos

--- a/tests/unittest_fem.py
+++ b/tests/unittest_fem.py
@@ -1,0 +1,56 @@
+import unittest
+import pyeit.eit.fem
+
+
+class TestVoltageMeterMethod(unittest.TestCase):
+    def test_std(self):
+        el = 16
+        step = 1
+        ex_mat = pyeit.eit.fem.eit_scan_lines(ne=el, dist=step)
+        parser = None
+        res = [
+            pyeit.eit.fem.voltage_meter(ex_line=line, n_el=el, step=step, parser=parser)
+            for line in ex_mat
+        ]
+        # test size of each array > 0
+        self.assertTrue(all(r.size > 0 for r in res))
+
+    def test_meas_current(self):
+        el = 16
+        step = 1
+        ex_mat = pyeit.eit.fem.eit_scan_lines(ne=el, dist=step)
+        parser = "meas_current"
+        res = [
+            pyeit.eit.fem.voltage_meter(ex_line=line, n_el=el, step=step, parser=parser)
+            for line in ex_mat
+        ]
+        # test size of each array > 0
+        self.assertTrue(all(r.size > 0 for r in res))
+
+
+class TestVoltageMeterNdMethod(unittest.TestCase):
+    def test_std(self):
+        el = 16
+        step = 1
+        ex_mat = pyeit.eit.fem.eit_scan_lines(ne=el, dist=step)
+        parser = None
+        res = pyeit.eit.fem.voltage_meter_nd(
+            ex_mat=ex_mat, n_el=el, step=step, parser=parser
+        )
+        # test size of each array > 0
+        self.assertTrue(all(r.size > 0 for r in res))
+
+    def test_meas_current(self):
+        el = 16
+        step = 1
+        ex_mat = pyeit.eit.fem.eit_scan_lines(ne=el, dist=step)
+        parser = "meas_current"
+        res = pyeit.eit.fem.voltage_meter_nd(
+            ex_mat=ex_mat, n_el=el, step=step, parser=parser
+        )
+        # test size of each array > 0
+        self.assertTrue(all(r.size > 0 for r in res))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest_fem.py
+++ b/tests/unittest_fem.py
@@ -4,24 +4,24 @@ import pyeit.eit.fem
 
 class TestVoltageMeterMethod(unittest.TestCase):
     def test_std(self):
-        el = 16
+        n_el = 16
         step = 1
-        ex_mat = pyeit.eit.fem.eit_scan_lines(ne=el, dist=step)
+        ex_mat = pyeit.eit.fem.eit_scan_lines(n_el=n_el, dist=step)
         parser = None
         res = [
-            pyeit.eit.fem.voltage_meter(ex_line=line, n_el=el, step=step, parser=parser)
+            pyeit.eit.fem.voltage_meter(ex_line=line, n_el=n_el, step=step, parser=parser)
             for line in ex_mat
         ]
         # test size of each array > 0
         self.assertTrue(all(r.size > 0 for r in res))
 
     def test_meas_current(self):
-        el = 16
+        n_el = 16
         step = 1
-        ex_mat = pyeit.eit.fem.eit_scan_lines(ne=el, dist=step)
+        ex_mat = pyeit.eit.fem.eit_scan_lines(n_el=n_el, dist=step)
         parser = "meas_current"
         res = [
-            pyeit.eit.fem.voltage_meter(ex_line=line, n_el=el, step=step, parser=parser)
+            pyeit.eit.fem.voltage_meter(ex_line=line, n_el=n_el, step=step, parser=parser)
             for line in ex_mat
         ]
         # test size of each array > 0
@@ -30,23 +30,23 @@ class TestVoltageMeterMethod(unittest.TestCase):
 
 class TestVoltageMeterNdMethod(unittest.TestCase):
     def test_std(self):
-        el = 16
+        n_el = 16
         step = 1
-        ex_mat = pyeit.eit.fem.eit_scan_lines(ne=el, dist=step)
+        ex_mat = pyeit.eit.fem.eit_scan_lines(n_el=n_el, dist=step)
         parser = None
         res = pyeit.eit.fem.voltage_meter_nd(
-            ex_mat=ex_mat, n_el=el, step=step, parser=parser
+            ex_mat=ex_mat, n_el=n_el, step=step, parser=parser
         )
         # test size of each array > 0
         self.assertTrue(all(r.size > 0 for r in res))
 
     def test_meas_current(self):
-        el = 16
+        n_el = 16
         step = 1
-        ex_mat = pyeit.eit.fem.eit_scan_lines(ne=el, dist=step)
+        ex_mat = pyeit.eit.fem.eit_scan_lines(n_el=n_el, dist=step)
         parser = "meas_current"
         res = pyeit.eit.fem.voltage_meter_nd(
-            ex_mat=ex_mat, n_el=el, step=step, parser=parser
+            ex_mat=ex_mat, n_el=n_el, step=step, parser=parser
         )
         # test size of each array > 0
         self.assertTrue(all(r.size > 0 for r in res))


### PR DESCRIPTION
Hy,

I found I think a solution to my [issue-1211346947](https://github.com/liubenyuan/pyEIT/issues/41#issue-1211346947)

the `self.J` was empty because of `voltage_meter` was corrupted. The bool array mask was wrong... (@ChabaneArmaury I must admit I the not at the begining of the if condition is confusing...) 

>not (m == drv_a or m == drv_b or n == drv_a or n == drv_b) or meas_current

is equivalent to 

>diff_pairs_mask = np.array(
        ((m != drv_a) & (m != drv_b) & (n != drv_a) & (n != drv_b)) | meas_current
    )

I didn't have time to check `voltage_meter_nd` but I will do it and after testing it I will make PR if needed!

Cheers