### PR TITLE
Issue setup small fix + optional meas_pattern

### DIFF
--- a/pyeit/eit/base.py
+++ b/pyeit/eit/base.py
@@ -63,8 +63,11 @@ class EitBase(ABC):
 
         Notes
         -----
-        parser is required for your code to be compatible with
-        (a) simulation data set or (b) FMMU data set
+            - parser is required for your code to be compatible with
+            (a) simulation data set or (b) FMMU data set
+            - To pass a custom measurement pattern use the kwarg meas_pattern
+            pay attenteion that the meas_pattern should be an nd.array of shape
+            (n_exc, n_meas_per_exc, 2). If not TypeError will be raised.
         """
         if ex_mat is None:
             ex_mat = eit_scan_lines(len(el_pos), 8)
@@ -73,6 +76,7 @@ class EitBase(ABC):
 
         # build forward solver
         self.fwd = Forward(mesh, el_pos)
+        self.meas_pattern= kwargs.pop("meas_pattern", None)
 
         # solving mesh structure
         self.mesh = mesh
@@ -222,6 +226,7 @@ class EitBase(ABC):
             perm=perm if perm is not None else self.perm,
             parser=self.parser,
             normalize=self.jac_normalized and allow_jac_norm,
+            meas_pattern=self.meas_pattern,
         )
 
     def _compute_b_matrix(self) -> np.ndarray:
@@ -234,7 +239,11 @@ class EitBase(ABC):
             BP matrix
         """
         return self.fwd.compute_b_matrix(
-            ex_mat=self.ex_mat, step=self.step, perm=self.perm, parser=self.parser
+            ex_mat=self.ex_mat,
+            step=self.step,
+            perm=self.perm,
+            parser=self.parser,
+            meas_pattern=self.meas_pattern,
         )
 
     def _check_solver_is_ready(self) -> None:

--- a/pyeit/eit/base.py
+++ b/pyeit/eit/base.py
@@ -76,7 +76,7 @@ class EitBase(ABC):
 
         # build forward solver
         self.fwd = Forward(mesh, el_pos)
-        self.meas_pattern= kwargs.pop("meas_pattern", None)
+        self.meas_pattern = kwargs.pop("meas_pattern", None)
 
         # solving mesh structure
         self.mesh = mesh

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -505,8 +505,8 @@ class Forward:
         ----------
         ex_mat : np.ndarray, optional
             stimulation/excitation matrix, of shape (n_exc, 2), by default `None`.
-            If `None` initialize stimulation matrix for 16 electrode and
-            apposition mode (see function `eit_scan_lines(16, 8)`)
+            If `None` initialize stimulation matrix for n_el electrode and
+            adjacent mode (see function `eit_scan_lines`)
             If single stimulation (ex_line) is passed only a list of length 2
             and np.ndarray of size 2 will be treated.
 
@@ -522,8 +522,8 @@ class Forward:
             or np.ndarray of shape (n_exc, 2)
         """
         if ex_mat is None:
-            # initialize the scan lines for 16 electrodes (default: apposition)
-            ex_mat = eit_scan_lines(16, 8)
+            # initialize the scan lines for 16 electrodes (default: adjacent)
+            ex_mat = eit_scan_lines(self.n_el, 1)
         elif isinstance(ex_mat, list) and len(ex_mat) == 2:
             # case ex_line has been passed instead of ex_mat
             ex_mat = np.array([ex_mat]).reshape((1, 2))  # build a 2D array

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -418,9 +418,10 @@ class Forward:
             measurements pattern / subtract_row pairs [N, M]; shape (n_exc, n_meas_per_exc, 2)
 
         """
-        return self._check_meas_pattern(ex_mat.shape[0], **kwargs) or voltage_meter(
-            ex_mat, n_el, step, parser
-        )
+        meas_pattern = self._check_meas_pattern(ex_mat.shape[0], **kwargs)
+        if meas_pattern is not None:
+            return meas_pattern
+        return voltage_meter(ex_mat, n_el, step, parser)
 
     def _check_meas_pattern(
         self, n_exc: int, meas_pattern: np.ndarray = None

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -458,7 +458,7 @@ class Forward:
         # test shape is something like (n_exc, :, 2)
         if meas_pattern.ndim != 3 or meas_pattern.shape[::2] != (n_exc, 2):
             raise TypeError(
-                f"Wrong shape of {meas_pattern=}, expected an ndarray; shape ({n_exc}, n_meas_per_exc, 2)"
+                f"Wrong shape of {meas_pattern=}: {meas_pattern.shape=}, expected an ndarray; shape ({n_exc}, n_meas_per_exc, 2)"
             )
 
         return meas_pattern

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -109,8 +109,8 @@ class Forward:
         (e.g. [0,7] or np.array([0,7]) or ex_mat[0].ravel). In that case a
         simplified version of `f` with shape (n_pts,)
         """
-        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
-        perm = self._get_perm(perm)  # check/init permitivity
+        ex_mat = self._check_ex_mat(ex_mat)  # check/init stimulation
+        perm = self._check_perm(perm)  # check/init permitivity
         f = self._compute_potential_distribution(ex_mat=ex_mat, perm=perm)
         # case ex_line has been passed instead of ex_mat
         # we return simplified version of f with shape (n_pts,)
@@ -151,9 +151,9 @@ class Forward:
                 v: np.ndarray
                     simulated boundary voltage measurements; shape(n_exc, n_el)
         """
-        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
-        perm = self._get_perm(perm)  # check/init permitivity
-        f = self._compute_potential_distribution(ex_mat=ex_mat, perm=perm)
+        ex_mat = self._check_ex_mat(ex_mat)  # check/init stimulation
+        perm = self._check_perm(perm)  # check/init permitivity
+        f = self._compute_potential_distribution(ex_mat, perm)
         # boundary measurements, subtract_row-voltages on electrodes
         diff_op = voltage_meter(ex_mat, n_el=self.n_el, step=step, parser=parser)
         return FwdResult(v=self._get_boundary_voltages(f, diff_op))
@@ -219,8 +219,8 @@ class Forward:
             after computation through call fwd.v0
 
         """
-        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
-        perm = self._get_perm(perm)  # check/init permitivity
+        ex_mat = self._check_ex_mat(ex_mat)  # check/init stimulation
+        perm = self._check_perm(perm)  # check/init permitivity
         f = self._compute_potential_distribution(
             ex_mat=ex_mat, perm=perm, memory_4_jac=True
         )
@@ -281,8 +281,8 @@ class Forward:
         np.ndarray
             back-projection mappings (smear matrix); shape(n_exc, n_pts, 1), dtype= bool
         """
-        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
-        perm = self._get_perm(perm)  # check/init permitivity
+        ex_mat = self._check_ex_mat(ex_mat)  # check/init stimulation
+        perm = self._check_perm(perm)  # check/init permitivity
 
         f = self._compute_potential_distribution(ex_mat=ex_mat, perm=perm)
         f_el = f[:, self.el_pos]
@@ -356,7 +356,7 @@ class Forward:
             .reshape(b.shape[0:2])
         )
 
-    def _get_perm(self, perm: Union[int, float, np.ndarray] = None) -> np.ndarray:
+    def _check_perm(self, perm: Union[int, float, np.ndarray] = None) -> np.ndarray:
         """
         Check/init the permittivity on element
 
@@ -390,7 +390,7 @@ class Forward:
             )
         return perm
 
-    def _get_ex_mat(self, ex_mat: np.ndarray = None) -> np.ndarray:
+    def _check_ex_mat(self, ex_mat: np.ndarray = None) -> np.ndarray:
         """
         Check/init stimulation
 

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -109,6 +109,8 @@ class Forward:
         (e.g. [0,7] or np.array([0,7]) or ex_mat[0].ravel). In that case a
         simplified version of `f` with shape (n_pts,)
         """
+        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
+        perm = self._get_perm(perm)  # check/init permitivity
         f = self._compute_potential_distribution(ex_mat=ex_mat, perm=perm)
         # case ex_line has been passed instead of ex_mat
         # we return simplified version of f with shape (n_pts,)
@@ -149,6 +151,8 @@ class Forward:
                 v: np.ndarray
                     simulated boundary voltage measurements; shape(n_exc, n_el)
         """
+        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
+        perm = self._get_perm(perm)  # check/init permitivity
         f = self._compute_potential_distribution(ex_mat=ex_mat, perm=perm)
         # boundary measurements, subtract_row-voltages on electrodes
         diff_op = voltage_meter(ex_mat, n_el=self.n_el, step=step, parser=parser)
@@ -215,6 +219,8 @@ class Forward:
             after computation through call fwd.v0
 
         """
+        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
+        perm = self._get_perm(perm)  # check/init permitivity
         f = self._compute_potential_distribution(
             ex_mat=ex_mat, perm=perm, memory_4_jac=True
         )
@@ -275,6 +281,9 @@ class Forward:
         np.ndarray
             back-projection mappings (smear matrix); shape(n_exc, n_pts, 1), dtype= bool
         """
+        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
+        perm = self._get_perm(perm)  # check/init permitivity
+
         f = self._compute_potential_distribution(ex_mat=ex_mat, perm=perm)
         f_el = f[:, self.el_pos]
         # build bp projection matrix
@@ -327,9 +336,6 @@ class Forward:
             potential on nodes ; shape (n_exc, n_pts)
 
         """
-        ex_mat = self._get_ex_mat(ex_mat)  # check/init stimulation
-        perm = self._get_perm(perm)  # check/init permitivity
-
         # 1. calculate local stiffness matrix (on each element)
         ke = calculate_ke(self.pts, self.tri)
         # 2. assemble to global K

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -168,6 +168,10 @@ class TestFem(unittest.TestCase):
         res= fwd.solve_eit()
         self.assertTrue(isinstance(res.v, np.ndarray))
 
+        # test passing meas_pattern
+        res= fwd.solve_eit(ex_mat, meas_pattern=np.array([[[0, 1]],[[1, 0]]]))
+        self.assertTrue(isinstance(res.v, np.ndarray))
+
     def test_compute_jac(self):
         """test compute_jac using a simple mesh structure"""
         #TODO @ liubenyuan please checkt this test
@@ -189,6 +193,10 @@ class TestFem(unittest.TestCase):
         jac = fwd.compute_jac()
         self.assertTrue(isinstance(jac, np.ndarray))
 
+        # test passing meas_pattern
+        jac = fwd.compute_jac(ex_mat, meas_pattern=np.array([[[0, 1]]]))
+        self.assertTrue(isinstance(jac, np.ndarray))
+
     def test_compute_b_matrix(self):
         """test compute_jac using a simple mesh structure"""
 
@@ -206,6 +214,11 @@ class TestFem(unittest.TestCase):
         # test without passing any argument
         b = fwd.compute_b_matrix()
         self.assertTrue(isinstance(b, np.ndarray))
+
+        # test passing meas_pattern
+        b = fwd.compute_b_matrix(ex_mat, meas_pattern=np.array([[[0, 1]]]))
+        self.assertTrue(isinstance(b, np.ndarray))
+
 
 
 if __name__ == "__main__":

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -145,6 +145,9 @@ class TestFem(unittest.TestCase):
         f= fwd.solve(ex_mat, perm=mesh["perm"])
 
         self.assertTrue(np.allclose(f, f_truth))
+        # test without passing any argument
+        f= fwd.solve()
+        self.assertTrue(isinstance(f, np.ndarray))
 
     def test_solve_eit(self):
         """test solve using a simple mesh structure"""
@@ -156,14 +159,17 @@ class TestFem(unittest.TestCase):
         fwd.set_ref_el(mesh["ref"])
         ex_mat = np.array([[0, 1], [1, 0]])
         # include voltage differences on driving electrodes
-        fwd = fwd.solve_eit(ex_mat, parser="meas_current")
+        res = fwd.solve_eit(ex_mat, parser="meas_current")
         vdiff_truth = f_truth[el_pos[1]] - f_truth[el_pos[0]]
         v_truth = vdiff_truth * np.array([1, -1, -1, 1])
 
-        self.assertTrue(np.allclose(fwd.v, v_truth))
+        self.assertTrue(np.allclose(res.v, v_truth))
+        # test without passing any argument
+        res= fwd.solve_eit()
+        self.assertTrue(isinstance(res.v, np.ndarray))
 
     def test_compute_jac(self):
-        """test solve using a simple mesh structure"""
+        """test compute_jac using a simple mesh structure"""
         #TODO @ liubenyuan please checkt this test
         # compute_jac return jac with the "subtract_row part" here you wanted to test only the jac_i get from old solve method
         # the jac_i_truth correspond to the jac_truth!
@@ -179,6 +185,27 @@ class TestFem(unittest.TestCase):
         jac = fwd.compute_jac(ex_mat, perm=mesh["perm"], parser="meas_current" )
         
         self.assertTrue(np.allclose(jac, jac_truth))
+        # test without passing any argument
+        jac = fwd.compute_jac()
+        self.assertTrue(isinstance(jac, np.ndarray))
+
+    def test_compute_b_matrix(self):
+        """test compute_jac using a simple mesh structure"""
+
+        mesh, el_pos = _mesh_obj()
+        b_truth = np.array([]) # TODO @ liubenyuan
+
+        # testing solve
+        ex_mat = np.array([[0, 1]])
+        fwd = pyeit.eit.fem.Forward(mesh, el_pos)
+        # fix ref to be exactly the one in mesh
+        fwd.set_ref_el(mesh["ref"])
+        b = fwd.compute_b_matrix(ex_mat, perm=mesh["perm"], parser="meas_current" )
+        
+        # self.assertTrue(np.allclose(b, b_truth)) # TODO @ liubenyuan
+        # test without passing any argument
+        b = fwd.compute_b_matrix()
+        self.assertTrue(isinstance(b, np.ndarray))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hy @liubenyuan,

I saw you merged my precedent PR. could you already test it?
However I saw a small issue by trying to not pass ex_mat or perm to following method!
`solve`, `solve_eit`, `compute_jac` and `compute_b_matrix`.
- I solve it by setting them in the scope of each method  (instead in _compute_potential_dist which do not return them ...)
- I add in the  `test_fem.py ` a small tests to see if defauflt call of each methods do not throughout an error!

Moreover I have implemented an option to pass throught **kwargs a custom meas_patttern to `solve_eit`, `compute_jac` and `compute_b_matrix` and to `EitBase`!
- I added test for that in `test_fem.py `
- and I add some notes 