### PR TITLE
add jac_normalized in setup parameter for jac and remove init flag from solve_eit,...

### DIFF
--- a/examples/eit_dynamic_bp.py
+++ b/examples/eit_dynamic_bp.py
@@ -35,7 +35,7 @@ protocol_obj = protocol.create(n_el, dist_exc=1, step_meas=1, parser_meas="std")
 # calculate simulated data
 fwd = EITForward(mesh_obj, protocol_obj)
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """ 3. naive inverse solver using back-projection """
 eit = bp.BP(mesh_obj, protocol_obj)

--- a/examples/eit_dynamic_greit.py
+++ b/examples/eit_dynamic_greit.py
@@ -48,7 +48,7 @@ protocol_obj = protocol.create(n_el, dist_exc=1, step_meas=1, parser_meas="std")
 # calculate simulated data
 fwd = EITForward(mesh_obj, protocol_obj)
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """ 3. Construct using GREIT """
 eit = greit.GREIT(mesh_obj, protocol_obj)

--- a/examples/eit_dynamic_jac.py
+++ b/examples/eit_dynamic_jac.py
@@ -40,7 +40,7 @@ protocol_obj = protocol.create(n_el, dist_exc=8, step_meas=1, parser_meas="std")
 # calculate simulated data
 fwd = EITForward(mesh_obj, protocol_obj)
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """ 3. JAC solver """
 # Note: if the jac and the real-problem are generated using the same mesh,

--- a/examples/eit_dynamic_jac3d.py
+++ b/examples/eit_dynamic_jac3d.py
@@ -46,7 +46,7 @@ node_perm = sim2pts(pts, tri, np.real(mesh_new.perm))
 
 # calculate simulated data
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """ 3. JAC solver """
 # number of stimulation lines/patterns

--- a/examples/eit_dynamic_stack.py
+++ b/examples/eit_dynamic_stack.py
@@ -34,7 +34,7 @@ protocol_obj = protocol.create(n_el, dist_exc=[7, 3], step_meas=1, parser_meas="
 # forward solver
 fwd = EITForward(mesh_obj, protocol_obj)
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """ 3. solving using dynamic EIT """
 # number of stimulation lines/patterns

--- a/examples/eit_dynamic_svd.py
+++ b/examples/eit_dynamic_svd.py
@@ -41,7 +41,7 @@ protocol_obj = protocol.create(n_el, dist_exc=8, step_meas=1, parser_meas="std")
 # calculate simulated data
 fwd = EITForward(mesh_obj, protocol_obj)
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """ 3. JAC solver """
 # Note: if the jac and the real-problem are generated using the same mesh,

--- a/examples/eit_static_GN_3D.py
+++ b/examples/eit_static_GN_3D.py
@@ -45,7 +45,7 @@ node_perm = sim2pts(pts, tri, np.real(tri_perm))
 
 # calculate simulated data
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """  Static GN Solver"""
 # number of stimulation lines/patterns

--- a/examples/eit_static_jac.py
+++ b/examples/eit_static_jac.py
@@ -32,7 +32,7 @@ perm = mesh_new.perm
 # %% calculate simulated data
 protocol_obj = protocol.create(n_el, dist_exc=1, step_meas=1, parser_meas="std")
 fwd = EITForward(mesh_obj, protocol_obj)
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 # plot
 fig, ax = plt.subplots(figsize=(9, 6))

--- a/examples/paper_eit2016b.py
+++ b/examples/paper_eit2016b.py
@@ -45,7 +45,7 @@ protocol_obj = protocol.create(n_el, dist_exc=1, step_meas=1, parser_meas="std")
 # calculate simulated data
 fwd = EITForward(mesh_obj, protocol_obj)
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """ ax2. BP """
 eit = bp.BP(mesh_obj, protocol_obj)

--- a/examples/softx/figure03.py
+++ b/examples/softx/figure03.py
@@ -44,7 +44,7 @@ protocol_obj = protocol.create(n_el, dist_exc=1, step_meas=1, parser_meas="std")
 # calculate simulated data
 fwd = EITForward(mesh_obj, protocol_obj)
 v0 = fwd.solve_eit()
-v1 = fwd.solve_eit(perm=mesh_new.perm, init=True)
+v1 = fwd.solve_eit(perm=mesh_new.perm)
 
 """ ax2. BP """
 eit = bp.BP(mesh_obj, protocol_obj)

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -50,17 +50,8 @@ class Forward:
             permittivity on elements ; shape (n_tri,).
             if `None`, assemble_pde is aborded
 
-        Raise
-        -------
-        Warning
-             if perm is `None`, just for information
-
         """
         if perm is None:
-            warnings.warn(
-                ">> initial stiffness matrix based on self.mesh.perm will be used ",
-                stacklevel=2,
-            )
             return
         perm = self.mesh.get_valid_perm(perm)
         self.kg = assemble(

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -58,7 +58,7 @@ class Forward:
         """            
         if perm is None:
             warnings.warn(
-                f"You passed a permittivity = {perm}, ", stacklevel=2
+                ">> initial stiffness matrix based on self.mesh.perm will be used ", stacklevel=2
             )
             return
         perm = self.mesh.get_valid_perm(perm)

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -49,16 +49,17 @@ class Forward:
         perm : Union[int, float, np.ndarray]
             permittivity on elements ; shape (n_tri,).
             if `None`, assemble_pde is aborded
-            
+
         Raise
         -------
         Warning
              if perm is `None`, just for information
 
-        """            
+        """
         if perm is None:
             warnings.warn(
-                ">> initial stiffness matrix based on self.mesh.perm will be used ", stacklevel=2
+                ">> initial stiffness matrix based on self.mesh.perm will be used ",
+                stacklevel=2,
             )
             return
         perm = self.mesh.get_valid_perm(perm)
@@ -193,7 +194,7 @@ The mesh use {m_n_el} electrodes, and the protocol use only {p_n_el} electrodes 
         ----------
         perm : Union[int, float, np.ndarray], optional
             permittivity on elements ; shape (n_tri,), by default `None`.
-            if perm is `None`, the computation of Jacobian matrix will be based 
+            if perm is `None`, the computation of Jacobian matrix will be based
             on the permittivity of the mesh, self.mesh.perm
         normalize : bool, optional
             flag for Jacobian normalization, by default False.
@@ -244,7 +245,7 @@ The mesh use {m_n_el} electrodes, and the protocol use only {p_n_el} electrodes 
         ----------
         perm : Union[int, float, np.ndarray], optional
             permittivity on elements ; shape (n_tri,), by default `None`.
-            if perm is `None`, the computation of smear matrix will be based 
+            if perm is `None`, the computation of smear matrix will be based
             on the permittivity of the mesh, self.mesh.perm
 
         Returns

--- a/pyeit/eit/greit.py
+++ b/pyeit/eit/greit.py
@@ -34,6 +34,7 @@ class GREIT(EitBase):
         n: int = 32,
         s: float = 20.0,
         ratio: float = 0.1,
+        jac_normalized: bool = False,
     ) -> None:
         """
         Setup GREIT solver
@@ -54,6 +55,9 @@ class GREIT(EitBase):
             control the blur, by default 20.0
         ratio : float, optional
             desired ratio, by default 0.1
+        jac_normalized : bool, optional
+            normalize the jacobian using f0 computed from input perm, by
+            default False
 
         Raises
         ------
@@ -75,13 +79,21 @@ class GREIT(EitBase):
         # parameters for GREIT projection
         if w is None:
             w = np.ones_like(self.mesh.perm)
-        self.params = {"w": w, "p": p, "lamb": lamb, "n": n, "s": s, "ratio": ratio}
+        self.params = {
+            "w": w,
+            "p": p,
+            "lamb": lamb,
+            "n": n,
+            "s": s,
+            "ratio": ratio,
+            "jac_normalize": jac_normalized,
+        }
 
         # Build grids and mask
         self.xg, self.yg, self.mask = meshgrid(self.mesh.node, n=n)
 
         w_mat = self._compute_grid_weights(self.xg, self.yg)
-        self.J, self.v0 = self.fwd.compute_jac()
+        self.J, self.v0 = self.fwd.compute_jac(normalize=jac_normalized)
         self.H = self._compute_h(jac=self.J, w_mat=w_mat)
         self.is_ready = True
 

--- a/pyeit/eit/jac.py
+++ b/pyeit/eit/jac.py
@@ -19,7 +19,11 @@ class JAC(EitBase):
     """A sensitivity-based EIT imaging class"""
 
     def setup(
-        self, p: float = 0.20, lamb: float = 0.001, method: str = "kotre", jac_normalized: bool = True
+        self,
+        p: float = 0.20,
+        lamb: float = 0.001,
+        method: str = "kotre",
+        jac_normalized: bool = True,
     ) -> None:
         """
         Setup JAC solver
@@ -39,7 +43,12 @@ class JAC(EitBase):
             default False
         """
         # passing imaging parameters
-        self.params = {"p": p, "lamb": lamb, "method": method, "jac_normalize": jac_normalized}
+        self.params = {
+            "p": p,
+            "lamb": lamb,
+            "method": method,
+            "jac_normalize": jac_normalized,
+        }
         # pre-compute H0 for dynamical imaging
         # H = (J.T*J + R)^(-1) * J.T
         self.J, self.v0 = self.fwd.compute_jac(normalize=jac_normalized)

--- a/pyeit/eit/jac.py
+++ b/pyeit/eit/jac.py
@@ -238,7 +238,7 @@ class JAC(EitBase):
         for i in range(maxiter):
 
             # forward solver,
-            jac, v0 = self.fwd.compute_jac(x0, init=True)
+            jac, v0 = self.fwd.compute_jac(x0)
             # Residual
             r0 = v - v0
 

--- a/pyeit/eit/jac.py
+++ b/pyeit/eit/jac.py
@@ -23,7 +23,7 @@ class JAC(EitBase):
         p: float = 0.20,
         lamb: float = 0.001,
         method: str = "kotre",
-        jac_normalized: bool = True,
+        jac_normalized: bool = False,
     ) -> None:
         """
         Setup JAC solver

--- a/pyeit/eit/jac.py
+++ b/pyeit/eit/jac.py
@@ -19,7 +19,7 @@ class JAC(EitBase):
     """A sensitivity-based EIT imaging class"""
 
     def setup(
-        self, p: float = 0.20, lamb: float = 0.001, method: str = "kotre"
+        self, p: float = 0.20, lamb: float = 0.001, method: str = "kotre", jac_normalized: bool = True
     ) -> None:
         """
         Setup JAC solver
@@ -34,12 +34,15 @@ class JAC(EitBase):
             JAC parameters, by default 0.001
         method : str, optional
             regularization methods ("kotre", "lm", "dgn" ), by default "kotre"
+        jac_normalized : bool, optional
+            normalize the jacobian using f0 computed from input perm, by
+            default False
         """
         # passing imaging parameters
-        self.params = {"p": p, "lamb": lamb, "method": method}
+        self.params = {"p": p, "lamb": lamb, "method": method, "jac_normalize": jac_normalized}
         # pre-compute H0 for dynamical imaging
         # H = (J.T*J + R)^(-1) * J.T
-        self.J, self.v0 = self.fwd.compute_jac()
+        self.J, self.v0 = self.fwd.compute_jac(normalize=jac_normalized)
         self.H = self._compute_h(self.J, p, lamb, method)
         self.is_ready = True
 


### PR DESCRIPTION
Hy @liubenyuan,

I saw that we forget the jac_normalized option for jac. is it also needed for greit? If yes I can added it!

By the way I just forget to ask you why you introduced the init flag on solve_eit, compute_b_matrix, compute_jac_matrix.
I think the init flag can be removed! each time you set it to true you pass a perm vector and viceversa, so it make it the flag redondant.  
I would suggest we recalculate kg only when perm is not None. It is maybe more intuitive, I was confused by using it in my own sofware. I made made some modifications (which made fem even more lighter!)
