### PR TITLE
et3 trim/meas_current

### DIFF
--- a/examples/eit_dynamic_bp.py
+++ b/examples/eit_dynamic_bp.py
@@ -39,7 +39,8 @@ v1 = fwd.solve_eit(perm=mesh_new.perm)
 """ 3. naive inverse solver using back-projection """
 eit = bp.BP(mesh_obj, protocol_obj)
 eit.setup(weight="none")
-ds = 192.0 * eit.solve(v1, v0, normalize=False)
+# the normalize for BP when dist_exc>4 should always be True
+ds = 192.0 * eit.solve(v1, v0, normalize=True)
 
 # extract node, element, alpha
 pts = mesh_obj.node

--- a/examples/eit_dynamic_stack.py
+++ b/examples/eit_dynamic_stack.py
@@ -39,7 +39,7 @@ v1 = fwd.solve_eit(perm=mesh_new.perm)
 """ 3. solving using dynamic EIT """
 # number of stimulation lines/patterns
 eit = jac.JAC(mesh_obj, protocol_obj)
-eit.setup(p=0.40, lamb=1e-3, method="kotre")
+eit.setup(p=0.40, lamb=1e-3, method="kotre", jac_normalized=False)
 ds = eit.solve(v1, v0, normalize=False)
 
 # extract node, element, alpha

--- a/examples/eit_external_mesh.py
+++ b/examples/eit_external_mesh.py
@@ -1,10 +1,11 @@
-from pyeit.mesh.external import load_mesh, place_electrodes_equal_spacing
+import os
+import numpy as np
 import matplotlib.pyplot as plt
-from pyeit.visual.plot import create_mesh_plot_2, create_plot, mesh_plot
+from pyeit.mesh.external import load_mesh, place_electrodes_equal_spacing
+from pyeit.visual.plot import create_mesh_plot, create_plot
 import pyeit.eit.protocol as protocol
 from pyeit.eit.jac import JAC
 from pyeit.eit.fem import EITForward
-import numpy as np
 
 
 def main():
@@ -17,21 +18,13 @@ def main():
     )
     n_electrodes = 16
 
-    sim_mesh = load_mesh(simulation_mesh_filename)
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    sim_mesh = load_mesh(os.path.join(current_dir, simulation_mesh_filename))
     electrode_nodes = place_electrodes_equal_spacing(sim_mesh, n_electrodes=16)
     sim_mesh.el_pos = np.array(electrode_nodes)
 
-    mesh_plot(
-        sim_mesh,
-        el_pos=electrode_nodes,
-        show_mesh=True,
-        show_number=True,
-        show_text=False,
-        figsize=None,
-    )
-
     fig, ax = plt.subplots()
-    create_mesh_plot_2(
+    create_mesh_plot(
         ax, sim_mesh, electrodes=electrode_nodes, coordinate_labels="radiological"
     )
 
@@ -45,7 +38,7 @@ def main():
     # Recon
     # Set up eit object
     pyeit_obj = JAC(sim_mesh, protocol_obj)
-    pyeit_obj.setup(p=0.5, lamb=0.001, method="kotre", perm=1)
+    pyeit_obj.setup(p=0.5, lamb=0.001, method="kotre", perm=1, jac_normalized=False)
 
     # # Dynamic solve simulated data
     ds_sim = pyeit_obj.solve(vi, vh, normalize=False)

--- a/examples/merit.py
+++ b/examples/merit.py
@@ -1,5 +1,7 @@
-from pyeit.mesh.external import load_mesh, place_electrodes_equal_spacing
+import os
+import numpy as np
 import matplotlib.pyplot as plt
+from pyeit.mesh.external import load_mesh, place_electrodes_equal_spacing
 from pyeit.visual.plot import (
     create_image_plot,
     create_layered_image_plot,
@@ -7,7 +9,6 @@ from pyeit.visual.plot import (
 import pyeit.eit.protocol as protocol
 from pyeit.eit.jac import JAC
 from pyeit.eit.fem import EITForward
-import numpy as np
 from pyeit.eit.render import model_inverse_uv, map_image
 import pyeit.quality.merit as merit
 
@@ -18,11 +19,12 @@ def main():
     #   Anterior direction towards the Y axis
     # This allows the 2D mesh to be displayed in the radiological view with no transformations
     simulation_mesh_filename = (
-        "example_data/mesha06_bumpychestslice_radiological_view_both_lungs_1_0-3.ply"
+        "./example_data/mesha06_bumpychestslice_radiological_view_both_lungs_1_0-3.ply"
     )
     n_electrodes = 16
 
-    sim_mesh = load_mesh(simulation_mesh_filename)
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    sim_mesh = load_mesh(os.path.join(current_dir, simulation_mesh_filename))
     electrode_nodes = place_electrodes_equal_spacing(sim_mesh, n_electrodes=16)
     sim_mesh.el_pos = np.array(electrode_nodes)
 

--- a/pyeit/eit/jac.py
+++ b/pyeit/eit/jac.py
@@ -131,7 +131,7 @@ class JAC(EitBase):
     ) -> np.ndarray:
         """
         a 'naive' back projection using the transpose of Jac.
-        This scheme is the one published by kotre (1989):
+        This scheme is the one published by kotre (1989), see note [1].
 
         Parameters
         ----------
@@ -166,7 +166,7 @@ class JAC(EitBase):
         if normalize:
             dv = np.log(np.abs(v1) / np.abs(v0)) * np.sign(v0.real)
         else:
-            dv = v1 - v0
+            dv = (v1 - v0) * np.sign(v0.real)
         # s_r = J^Tv_r
         ds = -np.dot(self.J.conj().T, dv)
         return np.exp(ds) - 1.0

--- a/pyeit/visual/plot.py
+++ b/pyeit/visual/plot.py
@@ -49,8 +49,6 @@ def create_mesh_plot(
     """
     Creates a plot to display a 2d mesh. Optionally plots electrode positions and adds coordinate labels.
 
-    (This is an alternative to pyeit.visual.plot.mesh_plot)
-
     Parameters
     ----------
     ax:

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -59,8 +59,8 @@ def _mesh_obj_large():
 
 
 def _protocol_obj(ex_mat, n_el, step_meas, parser_meas):
-    meas_mat = build_meas_pattern_std(ex_mat, n_el, step_meas, parser_meas)
-    return PyEITProtocol(ex_mat, meas_mat)
+    meas_mat, keep_ba = build_meas_pattern_std(ex_mat, n_el, step_meas, parser_meas)
+    return PyEITProtocol(ex_mat, meas_mat, keep_ba)
 
 
 class TestFem(unittest.TestCase):


### PR DESCRIPTION
Changes:
  - A `keep_ba` (Keep index boolean array) is added to `PyEITProtocol` dataclass.
  - `ET3()` in `pyeit/io/et3.py` now use `meas_current` (default False) option instead of `trim`.
  - A `PyEITProtocol` object is required for ET3(). The data is trimmed using `protocol_obj.keep_ba` when `meas_current` is False.
  - Minor tweak/correct the examples in example files.